### PR TITLE
ci: adding unit tests

### DIFF
--- a/aws_test.go
+++ b/aws_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+func TestRemovePathFromRoleARN(t *testing.T) {
+
+	// Tests if a valid path is removed from role ARN
+	t.Run("Remove valid path from role ARN", func(t *testing.T) {
+		arn := "arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/eu-west-1/roleName"
+		path := "/aws-reserved/sso.amazonaws.com/eu-west-1/"
+
+		want := "arn:aws:iam::123456789012:role/roleName"
+		got := removePathFromRoleARN(arn, path)
+
+		if got != want {
+			t.Errorf("removePathFromRoleARN(%s, %s) = %s, want %s", arn, path, got, want)
+		}
+	})
+
+	// Tests if a invalid path is not removed from role ARN
+	t.Run("Remove not valitpath from role ARN", func(t *testing.T) {
+		arn := "arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/eu-west-1/roleName"
+		path := "/path/"
+
+		want := arn
+		got := removePathFromRoleARN(arn, path)
+
+		if got != want {
+			t.Errorf("removePathFromRoleARN(%s, %s) = %s, want %s", arn, path, got, want)
+		}
+	})
+}
+
+func TestTranslatePermissionSetNameToARN(t *testing.T) {
+	mapping := SSORoleMapping{
+		RoleARN:       "",
+		PermissionSet: "devops",
+		Username:      "",
+		Groups:        []string{},
+		UserID:        "",
+	}
+
+	// Test when permission set does not exist
+	t.Run("Role exist", func(t *testing.T) {
+
+		iamRoles := []types.Role{{
+			RoleName: aws.String("AWSReservedSSO_devops_0123456789abcdef"),
+			Path:     aws.String("/path/"),
+			Arn:      aws.String("arn:aws:iam::123456789012:role/path/AWSReservedSSO_devops_0123456789abcdef"),
+		}}
+
+		want := SSORoleMapping{
+			RoleARN:       "arn:aws:iam::123456789012:role/AWSReservedSSO_devops_0123456789abcdef",
+			PermissionSet: "",
+			Username:      "",
+			Groups:        []string{},
+			UserID:        "",
+		}
+
+		got, _ := translatePermissionSetNameToARN(mapping, iamRoles)
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("TranslatePermissionSetNameToARNFound() returned unexpected object: %+v, want %+v", got, want)
+		}
+	})
+
+	// Test when permission set does exist
+	t.Run("Role does not exist", func(t *testing.T) {
+		iamRoles := []types.Role{{
+			RoleName: aws.String("AWSReservedSSO_sre_0123456789abcdef"),
+			Path:     aws.String("/path/"),
+			Arn:      aws.String("arn:aws:iam::123456789012:role/path/AWSReservedSSO_sre_0123456789abcdef"),
+		}}
+
+		want := fmt.Sprintf("permission set %s not found in AWS IAM service", mapping.PermissionSet)
+		_, got := translatePermissionSetNameToARN(mapping, iamRoles)
+
+		if got.Error() != want {
+			t.Errorf("Got unexpected error: %s, was expecting to get: %s", got, want)
+		}
+	})
+
+}

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/aws/smithy-go v1.14.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
@@ -44,6 +45,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/net v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
 github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
+github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -90,6 +92,8 @@ github.com/onsi/ginkgo/v2 v2.9.4 h1:xR7vG4IXt5RWx6FfIjyAtsoMAtnc3C/rFXBBd2AjZwE=
 github.com/onsi/ginkgo/v2 v2.9.4/go.mod h1:gCQYp2Q+kSoIj7ykSVb9nskRSsR6PUj4AiLywzIhbKM=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -1,0 +1,332 @@
+package main
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetConfigMap(t *testing.T) {
+	// Test when ConfigMap does not exist
+	t.Run("ConfigMap does not exist", func(t *testing.T) {
+
+		fakeClientSet := fake.NewSimpleClientset()
+
+		_, err := getConfigMap(fakeClientSet, "NOT_EXISTING_CONFIGMAP", "NOT_EXISTING_NAMESPASCE")
+		if !errors.IsNotFound(err) {
+			t.Errorf("Got unexpected error: %s, was expecting to get NotFound", err)
+		}
+	})
+
+	// Test when ConfigMap exist
+	t.Run("ConfigMap exist", func(t *testing.T) {
+
+		want := &v1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "NOT_EXISTING_CONFIGMAP",
+				Namespace:   "NOT_EXISTING_NAMESPASCE",
+				Annotations: map[string]string{},
+			},
+		}
+
+		fakeClientSet := fake.NewSimpleClientset(want)
+
+		got, err := getConfigMap(fakeClientSet, want.Name, want.Namespace)
+
+		if err != nil {
+			t.Errorf("Got unexpected error: %s, was expecting to get nil", err)
+		}
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("getConfigMap() returned unexpected object: %+v, want %+v", got, want)
+		}
+	})
+}
+
+func TestSetConfigMap(t *testing.T) {
+
+	// Test when ConfigMap does no exist
+	t.Run("ConfigMap does not exist", func(t *testing.T) {
+
+		// Define a fake namespace
+		ns := &v1.Namespace{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Namespace",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "TEST_NAMESPACE",
+				Annotations: map[string]string{},
+			},
+		}
+
+		// Create a fake client
+		fakeClientSet := fake.NewSimpleClientset(ns)
+
+		// Define data for configMap
+		cmdata := map[string]string{
+			"mapAccounts": "[]\n",
+			"mapUsers":    "[]\n",
+			"mapRoles":    "- rolearn: arn:aws:iam::190058439852:role/platform-development-dev-eks2019102907023762960000000b\n  username: system:node:{{EC2PrivateDNSName}}\n  groups:\n    - system:bootstrappers\n    - system:nodes\n- rolearn: arn:aws:iam::190058439852:role/terraform-role\n  username: terraform:{{SessionName}}\n  groups:\n    - system:masters\n- rolearn: arn:aws:iam::190058439852:role/AWSReservedSSO_admin-dev-pu_07572db8b73986b8\n  username: admin:{{SessionName}}\n  groups:\n    - system:masters\n- username: admin:{{SessionName}}\n",
+		}
+
+		// Update configMap which does not exist (should create new configMap)
+		err := setConfigMap(fakeClientSet, "NOT_EXISTING_CONFIGMAP", ns.Name, cmdata)
+		if err != nil {
+			t.Errorf("Got unexpected error: %s, was expecting to get nil", err)
+		}
+
+		// Check if configMap was created
+		cm, err := fakeClientSet.CoreV1().ConfigMaps(ns.Name).Get(context.TODO(), "NOT_EXISTING_CONFIGMAP", metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("Got unexpected error: %s, was expecting to get nil", err)
+		}
+
+		// Check if configMap created has data we expect
+		if !reflect.DeepEqual(cm.Data, cmdata) {
+			t.Errorf("setConfigMap() created unexpected object: %+v, want %+v", cm.Data, cmdata)
+		}
+
+	})
+
+	// Test when namespace does exist
+	t.Run("ConfigMap and Namespace does not exist", func(t *testing.T) {
+
+		var fakeClientSet *fake.Clientset = fake.NewSimpleClientset()
+
+		cmdata := map[string]string{
+			"mapAccounts": "[]\n",
+			"mapUsers":    "[]\n",
+			"mapRoles":    "- rolearn: arn:aws:iam::190058439852:role/platform-development-dev-eks2019102907023762960000000b\n  username: system:node:{{EC2PrivateDNSName}}\n  groups:\n    - system:bootstrappers\n    - system:nodes\n- rolearn: arn:aws:iam::190058439852:role/terraform-role\n  username: terraform:{{SessionName}}\n  groups:\n    - system:masters\n- rolearn: arn:aws:iam::190058439852:role/AWSReservedSSO_admin-dev-pu_07572db8b73986b8\n  username: admin:{{SessionName}}\n  groups:\n    - system:masters\n- username: admin:{{SessionName}}\n",
+		}
+
+		err := setConfigMap(fakeClientSet, "NOT_EXISTING_CONFIGMAP", "NOT_EXISTING_NAMESPACE", cmdata)
+		if err != nil {
+			t.Errorf("Got unexpected error: %s, was expecting to get nil", err)
+		}
+
+		// Check if configMap was created
+		cm, err := fakeClientSet.CoreV1().ConfigMaps("NOT_EXISTING_NAMESPACE").Get(context.TODO(), "NOT_EXISTING_CONFIGMAP", metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("Got unexpected error: %s, was expecting to get nil", err)
+		}
+
+		// Check if configMap created has data we expect
+		if !reflect.DeepEqual(cm.Data, cmdata) {
+			t.Errorf("setConfigMap() created unexpected object: %+v, want %+v", cm.Data, cmdata)
+		}
+	})
+
+	// Test when ConfigMap does not exist
+	t.Run("ConfigMap does exist", func(t *testing.T) {
+
+		// Define a fake namespace
+		ns := &v1.Namespace{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Namespace",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "TEST_NAMESPACE",
+				Annotations: map[string]string{},
+			},
+		}
+
+		// Define a fake configMap
+		cm := &v1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "TEST_CONFIGMAP",
+				Namespace:   ns.Name,
+				Annotations: map[string]string{},
+			},
+			Data: map[string]string{
+				"mapAccounts": "[]\n",
+				"mapUsers":    "[]\n",
+				"mapRoles":    "- rolearn: arn:aws:iam::190058439852:role/platform-development-dev-eks2019102907023762960000000b\n  username: system:node:{{EC2PrivateDNSName}}\n  groups:\n    - system:bootstrappers\n    - system:nodes\n\n",
+			},
+		}
+
+		// Create a fake client
+		fakeClientSet := fake.NewSimpleClientset(ns, cm)
+
+		cmdata := map[string]string{
+			"mapAccounts": "[]\n",
+			"mapUsers":    "[]\n",
+			"mapRoles":    "- rolearn: arn:aws:iam::190058439852:role/platform-development-dev-eks2019102907023762960000000b\n  username: system:node:{{EC2PrivateDNSName}}\n  groups:\n    - system:bootstrappers\n    - system:nodes\n- rolearn: arn:aws:iam::190058439852:role/terraform-role\n  username: terraform:{{SessionName}}\n  groups:\n    - system:masters\n- rolearn: arn:aws:iam::190058439852:role/AWSReservedSSO_admin-dev-pu_07572db8b73986b8\n  username: admin:{{SessionName}}\n  groups:\n    - system:masters\n- username: admin:{{SessionName}}\n",
+		}
+
+		err := setConfigMap(fakeClientSet, cm.Name, ns.Name, cmdata)
+		if err != nil {
+			t.Errorf("Got unexpected error: %s, was expecting to get nil", err)
+		}
+
+		// Check if configMap was created
+		updatedConfigMap, err := fakeClientSet.CoreV1().ConfigMaps(ns.Name).Get(context.TODO(), cm.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("Got unexpected error: %s, was expecting to get nil", err)
+		}
+
+		// Check if configMap created has data we expect
+		if !reflect.DeepEqual(updatedConfigMap.Data, cmdata) {
+			t.Errorf("setConfigMap() created unexpected object: %+v, want %+v", cm.Data, cmdata)
+		}
+
+	})
+}
+
+func TestTransformRoleMappings(t *testing.T) {
+	// Test when IAM role does not exist for provided PermissionSet
+	t.Run("IAM role does not exist for provided permission set name", func(t *testing.T) {
+		mappings := []SSORoleMapping{
+			{
+				RoleARN:       "arn:aws:iam::123456789012:role/AWSReservedSSO_devops_0123456789abcdef",
+				PermissionSet: "",
+				Username:      "",
+				Groups:        []string{},
+			},
+			{
+				RoleARN:       "",
+				PermissionSet: "sre",
+				Username:      "",
+				Groups:        []string{},
+			},
+		}
+
+		roles := []types.Role{
+			{
+				RoleName: aws.String("AWSReservedSSO_devops_0123456789abcdef"),
+				Path:     aws.String("/aws-reserved/sso.amazonaws.com/eu-west-1/"),
+				Arn:      aws.String("arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/eu-west-1/AWSReservedSSO_devops_0123456789abcdef"),
+			},
+		}
+
+		want := []SSORoleMapping{
+			{
+				RoleARN:       "arn:aws:iam::123456789012:role/AWSReservedSSO_devops_0123456789abcdef",
+				PermissionSet: "",
+				Username:      "",
+				Groups:        []string{},
+			},
+		}
+
+		got := transformRoleMappings(mappings, roles)
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("TransformRoleMappings() returned unexpected object: %+v, want %+v", got, want)
+		}
+	})
+
+	// Test when []SSORoleMapping does not need translation (no permissionSet names are provided)
+	t.Run("Provided input does not need transformation", func(t *testing.T) {
+		mappings := []SSORoleMapping{
+			{
+				RoleARN:       "arn:aws:iam::123456789012:role/AWSReservedSSO_devops_0123456789abcdef",
+				PermissionSet: "",
+				Username:      "",
+				Groups:        []string{},
+			},
+			{
+				RoleARN:       "arn:aws:iam::123456789012:role/AWSReservedSSO_sre_0123456789abcdef",
+				PermissionSet: "",
+				Username:      "",
+				Groups:        []string{},
+			},
+		}
+
+		roles := []types.Role{
+			{
+				RoleName: aws.String("AWSReservedSSO_devops_0123456789abcdef"),
+				Path:     aws.String("/aws-reserved/sso.amazonaws.com/eu-west-1/"),
+				Arn:      aws.String("arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/eu-west-1/AWSReservedSSO_devops_0123456789abcdef"),
+			},
+		}
+
+		want := []SSORoleMapping{
+			{
+				RoleARN:       "arn:aws:iam::123456789012:role/AWSReservedSSO_devops_0123456789abcdef",
+				PermissionSet: "",
+				Username:      "",
+				Groups:        []string{},
+			},
+			{
+				RoleARN:       "arn:aws:iam::123456789012:role/AWSReservedSSO_sre_0123456789abcdef",
+				PermissionSet: "",
+				Username:      "",
+				Groups:        []string{},
+			},
+		}
+
+		got := transformRoleMappings(mappings, roles)
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("TransformRoleMappings() returned unexpected object: %+v, want %+v", got, want)
+		}
+	})
+
+	// Test when PermissionSet name was provided and corresponding AWS IAM role exists
+	t.Run("Translate permissionSet name to role ARN", func(t *testing.T) {
+		mappings := []SSORoleMapping{
+			{
+				RoleARN:       "",
+				PermissionSet: "devops",
+				Username:      "",
+				Groups:        []string{},
+			},
+			{
+				RoleARN:       "",
+				PermissionSet: "sre",
+				Username:      "",
+				Groups:        []string{},
+			},
+		}
+
+		roles := []types.Role{
+			{
+				RoleName: aws.String("AWSReservedSSO_devops_0123456789abcdef"),
+				Path:     aws.String("/aws-reserved/sso.amazonaws.com/eu-west-1/"),
+				Arn:      aws.String("arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/eu-west-1/AWSReservedSSO_devops_0123456789abcdef"),
+			},
+			{
+				RoleName: aws.String("AWSReservedSSO_sre_0123456789abcdef"),
+				Path:     aws.String("/aws-reserved/sso.amazonaws.com/eu-west-1/"),
+				Arn:      aws.String("arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/eu-west-1/AWSReservedSSO_sre_0123456789abcdef"),
+			},
+		}
+
+		want := []SSORoleMapping{
+			{
+				RoleARN:       "arn:aws:iam::123456789012:role/AWSReservedSSO_devops_0123456789abcdef",
+				PermissionSet: "",
+				Username:      "",
+				Groups:        []string{},
+			},
+			{
+				RoleARN:       "arn:aws:iam::123456789012:role/AWSReservedSSO_sre_0123456789abcdef",
+				PermissionSet: "",
+				Username:      "",
+				Groups:        []string{},
+			},
+		}
+
+		got := transformRoleMappings(mappings, roles)
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("TransformRoleMappings() returned unexpected object: %+v, want %+v", got, want)
+		}
+	})
+}


### PR DESCRIPTION
ci: refactoring kubernetes related methods to accept kubernetes ClientSet as an input argument so that it could be mocked, removing ENV VAR support from getCurrentNamespace() method as it now can be passed as a CLI argumenet
ci: adding unit tests