### PR TITLE
feat(helm): allowing to skip creation of serviceAccount and explicitly provide a serviceAccount name

### DIFF
--- a/chart/aws-iam-authenticator-sso-wrapper/Chart.yaml
+++ b/chart/aws-iam-authenticator-sso-wrapper/Chart.yaml
@@ -2,7 +2,7 @@ name: aws-iam-authenticator-sso-wrapper
 description: aws-iam-authenticator-sso-wrapper Chart
 apiVersion: v2
 appVersion: v0.0.13
-version: v0.0.15
+version: v0.0.16
 home: https://github.com/justinas-b/aws-iam-authenticator-sso-wrapper
 maintainers:
   - name: justinas-b

--- a/chart/aws-iam-authenticator-sso-wrapper/templates/deployment.yaml
+++ b/chart/aws-iam-authenticator-sso-wrapper/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       annotations: {{- toYaml .Values.deployment.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ .Chart.Name }}
+      serviceAccountName: {{ .Values.serviceaccount.name }}
       {{- if .Values.deployment.imagePullSecrets }}
       imagePullSecrets: {{- toYaml .Values.deployment.imagePullSecrets | nindent 8 }}
       {{- end }}

--- a/chart/aws-iam-authenticator-sso-wrapper/templates/roleBinding.yaml
+++ b/chart/aws-iam-authenticator-sso-wrapper/templates/roleBinding.yaml
@@ -16,7 +16,7 @@ metadata:
     app.kubernetes.io/managed-by: helm
 subjects:
 - kind: ServiceAccount
-  name: {{ .Chart.Name }}
+  name: {{ .Values.serviceaccount.name }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: helm
 subjects:
 - kind: ServiceAccount
-  name: {{ .Chart.Name }}
+  name: {{ .Values.serviceaccount.name }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role

--- a/chart/aws-iam-authenticator-sso-wrapper/templates/serviceAccount.yaml
+++ b/chart/aws-iam-authenticator-sso-wrapper/templates/serviceAccount.yaml
@@ -1,8 +1,9 @@
 ---
+{{- if .Values.serviceaccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ .Values.serviceaccount.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Chart.Name }}
@@ -20,4 +21,5 @@ metadata:
   {{- if .Values.deployment.podLabels }}
   annotations: {{- toYaml .Values.serviceaccount.annotations | nindent 4 }}
   {{- end }}
+{{- end }}
 ---

--- a/chart/aws-iam-authenticator-sso-wrapper/values.yaml
+++ b/chart/aws-iam-authenticator-sso-wrapper/values.yaml
@@ -25,6 +25,8 @@ deployment:
     interval: 1800
     srcConfigmap: aws-auth
 serviceaccount:
+  create: true
+  name: aws-iam-authenticator-sso-wrapper
   labels:
     environment: "test"
   annotations:


### PR DESCRIPTION
Added the ability to decide whether or not to create a serviceaccount and to get the name from the values file to allow the creation of the service account separately 