### PR TITLE
feat: add option to disable automatic worker node role injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ it automatically:
   rolearn: arn:aws:iam::111122223333:role/my-node-role
   username: system:node:{{EC2PrivateDNSName}}
 ```
+This automatic worker node role injection can be disabled using the `--disable-auto-worker-node-role` flag
 
 The tool will process `aws-auth` ConfigMap from it's local kubernetes namespace and transform it to the format AWS EKS cluster expects. After processing ConfigMap, it's output is saved `kube-system` namespace where PermissionSet's name is translated to corresponding role ARN, meaning `"permissionset": AdminRole"` line will become `"rolearn": "arn:aws:iam::000000000000:role/AWSReservedSSO_AdminRole_0123456789abcdef"`
 
@@ -126,6 +127,8 @@ Usage of aws-iam-authenticator-sso-wrapper:
         AWS region to use when interacting with IAM service (default "us-east-1")
   -debug
         Enable debug logging
+  -disable-auto-worker-node-role
+        Disable automatic injection of worker node IAM role
   -dst-configmap string
         Name of the destination Kubernets ConfigMap which will be updated after transformation (default "aws-auth")
   -dst-namespace string

--- a/chart/aws-iam-authenticator-sso-wrapper/Chart.yaml
+++ b/chart/aws-iam-authenticator-sso-wrapper/Chart.yaml
@@ -1,8 +1,8 @@
 name: aws-iam-authenticator-sso-wrapper
 description: aws-iam-authenticator-sso-wrapper Chart
 apiVersion: v2
-appVersion: v0.1.0
-version: v0.1.0
+appVersion: v0.2.0
+version: v0.2.0
 home: https://github.com/justinas-b/aws-iam-authenticator-sso-wrapper
 maintainers:
   - name: justinas-b

--- a/chart/aws-iam-authenticator-sso-wrapper/templates/deployment.yaml
+++ b/chart/aws-iam-authenticator-sso-wrapper/templates/deployment.yaml
@@ -63,6 +63,9 @@ spec:
             {{- if .Values.deployment.applicationArguments.interval }}
             - "-interval={{ toYaml .Values.deployment.applicationArguments.interval }}"
             {{- end }}
+            {{- if .Values.deployment.applicationArguments.disableAutoWorkerNodeRole }}
+            - "--disable-auto-worker-node-role"
+            {{- end }}
             {{- if .Values.deployment.applicationArguments.debug }}
             - "-debug"
             {{- end }}

--- a/chart/aws-iam-authenticator-sso-wrapper/values.yaml
+++ b/chart/aws-iam-authenticator-sso-wrapper/values.yaml
@@ -10,7 +10,7 @@ deployment:
   #   - name: myImagePullSecret
   image:
     repository: justinasb/aws-iam-authenticator-sso-wrapper
-    tag: v0.1.0
+    tag: latest
     pullPolicy: IfNotPresent
   resources:
     limits:

--- a/chart/aws-iam-authenticator-sso-wrapper/values.yaml
+++ b/chart/aws-iam-authenticator-sso-wrapper/values.yaml
@@ -25,6 +25,7 @@ deployment:
     debug: true
     interval: 1800
     srcConfigmap: aws-auth
+    disableAutoWorkerNodeRole: false
 serviceaccount:
   create: true
   name: aws-iam-authenticator-sso-wrapper

--- a/main.go
+++ b/main.go
@@ -3,12 +3,13 @@ package main
 import (
 	"flag"
 	"fmt"
-	"go.uber.org/zap"
-	"gopkg.in/yaml.v2"
 	"os"
 	"os/signal"
 	"reflect"
 	"time"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -21,6 +22,7 @@ var (
 	debug                     bool
 	interval                  int
 	disableAutoWorkerNodeRole bool
+)
 
 // init is a special function in Go that is automatically called before the main function.
 func init() {


### PR DESCRIPTION
This commit adds a new command-line flag `--disable-auto-worker-node-role` that allows users to disable the automatic injection of worker node IAM role information into the aws-auth ConfigMap. When enabled, the application will skip adding worker node role bindings during ConfigMap updates.

The feature is also exposed in the Helm chart through the `deployment.applicationArguments.disableAutoWorkerNodeRole` value, which defaults to false to maintain backward compatibility.